### PR TITLE
fix: Route API Traffic Through CloudFront to Forward Headers

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export default function Home() {
   const [threats, setThreats] = useState('...');
 
   useEffect(() => {
-    const apiUrl = 'https://u1v9pb60g4.execute-api.us-east-2.amazonaws.com/default/getVisitorLocation'; 
+    const apiUrl = '/api/default/getVisitorLocation'; 
 
     // This check prevents the app from crashing if the URL isn't set.
     if (apiUrl.includes('PASTE_YOUR_API_ENDPOINT_URL_HERE') || !apiUrl) {


### PR DESCRIPTION
This PR corrects an issue where visitor location data was showing as "Unavailable".

The root cause was that the frontend was calling the API Gateway URL directly, bypassing CloudFront. As a result, the necessary CloudFront-Viewer-* headers were not being attached to the request, and the Lambda function could not determine the visitor's location.

### This fix implements the following architectural changes:

**New CloudFront Origin**: Added the API Gateway as a second origin in the CloudFront distribution.

New CloudFront Behavior: Created a new behavior for the path /api/* that routes all matching requests to the new API Gateway origin.

**Origin Request Policy**: Attached the Forward-Viewer-Location-Headers policy to the new behavior, ensuring all viewer headers are correctly passed to the Lambda function.

**Frontend Update**: Modified the apiUrl in page.tsx to use the relative path /api/default/getVisitorLocation, forcing the request through our CloudFront distribution.